### PR TITLE
Bumped spellcheck GHA from 0.17.0 to 0.27.0 (current version)

### DIFF
--- a/.github/workflows/spell_check.yml
+++ b/.github/workflows/spell_check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.17.0
+    - uses: rojopolis/spellcheck-github-actions@0.27.0
       name: Spellcheck
       with:
         source_files: '*.md'


### PR DESCRIPTION
This pull request updates to the most recent release version 0.27.0 of the spellcheck GitHub action, I can see that you are using 0.17.0, so an update could be useful to you. Let me know if you have any issues with the proposal and I will try to accommodate.

I have defined a [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy) for the action and the version you are using are soon to be a year old, so it will eventually be deleted from DockerHub.

I can recommend [Dependabot](https://github.com/dependabot) or [Renovate](https://github.com/marketplace/renovate) for keeping your GitHub actions up to date automatically, if you want a PR proposing a basic configuration, please let me know.